### PR TITLE
Potential fix for code scanning alert no. 45: Log Injection

### DIFF
--- a/src/main/java/com/gentlecorp/customer/service/CustomerReadService.java
+++ b/src/main/java/com/gentlecorp/customer/service/CustomerReadService.java
@@ -73,7 +73,17 @@ public class CustomerReadService {
     }
 
     public @NonNull Collection<Customer> find(@NonNull final Map<String, List<String>> searchCriteria) {
-        log.debug("find: searchCriteria={}", searchCriteria);
+        Map<String, List<String>> sanitizedSearchCriteria = sanitizeSearchCriteria(searchCriteria);
+        log.debug("find: searchCriteria={}", sanitizedSearchCriteria);
             return customerRepository.findAll();
+    }
+    private Map<String, List<String>> sanitizeSearchCriteria(Map<String, List<String>> searchCriteria) {
+        return searchCriteria.entrySet().stream()
+            .collect(Collectors.toMap(
+                entry -> entry.getKey().replaceAll("[\\r\\n]", ""),
+                entry -> entry.getValue().stream()
+                    .map(value -> value.replaceAll("[\\r\\n]", ""))
+                    .collect(Collectors.toList())
+            ));
     }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/Gentlecorp-Systems/gentlecorp-customer-service/security/code-scanning/45](https://github.com/Gentlecorp-Systems/gentlecorp-customer-service/security/code-scanning/45)

To fix the log injection issue, we need to sanitize the `searchCriteria` parameter before logging it. The best way to do this is to remove any potentially harmful characters, such as new-line characters, from the user input. We can achieve this by iterating over the entries in the `searchCriteria` map and sanitizing each key and value.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
